### PR TITLE
Addresses both local workstation and Bastion Server installation options, tenant creation and deletion commands

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -334,7 +334,9 @@ $ ansible-playbook -i localhost, -c local /tmp/3scale_multitenant.yml \
                     -e"orgName=$orgName" \
                     -e"ocpAdminId=$ocpAdminId" \
                     -e"tenantAdminId=$tenantAdminId" \
-                    -e"gw_project_name=$gw_project_name"
+                    -e"gw_project_name=$gw_project_name" \
+                    -e"rht_service_token_user=$rht_service_token_user" \
+                    -e"rht_service_token_password=$rht_service_token_password"
 -----
 
 

--- a/README.adoc
+++ b/README.adoc
@@ -313,15 +313,15 @@ Alternative to the ability to create a sequence of generica tenants, a _named_ t
 
 
 -----
-orgName=openbanking-prod
+export orgName=openbanking-prod
 
-ocpAdminId=ocp01                           #   name of OCP user that will have access to their corresponding API Mgmt related projects.
+export ocpAdminId=ocp01                           #   name of OCP user that will have access to their corresponding API Mgmt related projects.
 
-tenantAdminId=api01                        #   name of API user that will be the admin of their API tenants (and admins of thier own API gateways)
+export tenantAdminId=api01                        #   name of API user that will be the admin of their API tenants (and admins of thier own API gateways)
 
-CREATE_GWS_WITH_EACH_TENANT=true           #   if true, then an OCP project with API gateways will be created for each corresponding tenant in the same OCP cluster where API Manager resides
+export CREATE_GWS_WITH_EACH_TENANT=true           #   if true, then an OCP project with API gateways will be created for each corresponding tenant in the same OCP cluster where API Manager resides
 
-gw_project_name=$orgName-gw
+export gw_project_name=$orgName-gw
 
 
 $ ansible-playbook -i localhost, -c local /tmp/3scale_multitenant.yml \
@@ -352,7 +352,8 @@ The useId and password are generated using the following ansible variables found
 === Delete 3scale API manager
 
 -----
-REMOVE_TENANTS_ONLY=true
+export REMOVE_TENANTS_ONLY=true
+
 $ ansible-playbook -i localhost, -c local /tmp/3scale_multitenant.yml \
                     -e"ACTION=remove" \
                     -e"OCP_AMP_ADMIN_ID=$OCP_AMP_ADMIN_ID" \

--- a/README.adoc
+++ b/README.adoc
@@ -183,7 +183,13 @@ $ rht_service_token_password=<changeme> #   RHT Registry Service Account passwd 
 
 === Ansible Set-up
 
-. Install this role locally
+. Install this role on your bastion server:
++
+-----
+$ ansible-galaxy install gpe_mw_ansible.3scale_multitenant --force -p /etc/ansible/roles
+-----
++
+* Alternatively, if you are installing the role locally on your workstation computer:
 +
 -----
 $ ansible-galaxy install gpe_mw_ansible.3scale_multitenant --force -p $HOME/.ansible/roles

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -96,7 +96,7 @@ use_padded_tenant_numbers: true
 
 create_gws_with_each_tenant: "true"
 
-only_delete_tenants: "true"                
+only_delete_tenants: "{{REMOVE_TENANTS_ONLY}}"                
 
 tenant_api_gw_template_url: "https://raw.githubusercontent.com/gpe-mw-training/3scale_onpremise_implementation_labs/master/resources/rhte/3scale-apicast.yml"
 tenant_api_wildcard_gw_template_url: "https://raw.githubusercontent.com/gpe-mw-training/3scale_onpremise_implementation_labs/master/resources/rhte/3scale-wc-router.yml"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,9 +76,9 @@ smtp_passwd: changeme
 
 
 ######   new tenants    #######
- 
+
 # base name of OCP users that will have access to their corresponding API Mgmt related projects
-ocp_user_name_base: ocp                             
+ocp_user_name_base: ocp
 
 
 # initial base name of 3scale API administrator of each tenant; ie: api1, api2, api3 ...
@@ -94,7 +94,9 @@ tenantAdminPasswd: admin
 
 use_padded_tenant_numbers: true
 
-create_gws_with_each_tenant: "true"                
+create_gws_with_each_tenant: "true"
+
+only_delete_tenants: "true"                
 
 tenant_api_gw_template_url: "https://raw.githubusercontent.com/gpe-mw-training/3scale_onpremise_implementation_labs/master/resources/rhte/3scale-apicast.yml"
 tenant_api_wildcard_gw_template_url: "https://raw.githubusercontent.com/gpe-mw-training/3scale_onpremise_implementation_labs/master/resources/rhte/3scale-wc-router.yml"

--- a/tasks/remove_workload.yml
+++ b/tasks/remove_workload.yml
@@ -24,7 +24,7 @@
 
 - name: Remove user Project
   shell: "oc delete project {{API_MANAGER_NS}}"
-  when: {{ REMOVE_TENANTS_ONLY }} == "false"
+  when: not only_delete_tenants|bool
 
 - name: post_workload Tasks Complete
   debug:

--- a/tasks/remove_workload.yml
+++ b/tasks/remove_workload.yml
@@ -24,6 +24,7 @@
 
 - name: Remove user Project
   shell: "oc delete project {{API_MANAGER_NS}}"
+  when: {{ REMOVE_TENANTS_ONLY }} == "false"
 
 - name: post_workload Tasks Complete
   debug:

--- a/tasks/tenant_loop.yml
+++ b/tasks/tenant_loop.yml
@@ -1,27 +1,27 @@
 ---
 
 # The following is only appropriate when create generic tenants whose names are sequential
-# The following is skipped when creating a "named" tenant, ie; openbanking-dev  
+# The following is skipped when creating a "named" tenant, ie; openbanking-dev
 - block:
   - set_fact:
-      counter: "{{ item }}"   
+      counter: "{{ item }}"
 
   # Padded sequence number
   - block:
-    - set_fact: 
+    - set_fact:
         counter: "{{ '%02d'|format(item|int) }}"
-    - debug: 
+    - debug:
         msg: "{{ item }} padded to {{ counter }}"
     when: use_padded_tenant_numbers|bool
 
   # Name of ocp user that is an admin to the project where 3scale resources reside
   - set_fact:
       ocpAdminId: "{{ ocp_user_name_base }}{{ counter }}"
-  
+
   # Name of 3scale API administrator of the tenant
   - set_fact:
       tenantAdminId: "{{ tenant_admin_user_name_base }}{{ counter }}"
-  
+
   - set_fact:
       orgName: "{{ocpAdminId}}-{{API_MANAGER_NS}}"
 
@@ -46,12 +46,12 @@
       set_fact:
         tenantAdminEmail: "{{adminEmailUser}}%2B{{ counter }}%40{{adminEmailDomain}}"
     - debug:
-        msg: "{{ocpAdminId}} tenantAdminEmail = {{tenantAdminEmail}}" 
+        msg: "{{ocpAdminId}} tenantAdminEmail = {{tenantAdminEmail}}"
 
       # NOTE:  As of 3scale 2.2, this operation is not idempotent.
       #        It creates a new tenant given the same parameters.
       #        Public and Admin domains of these tenants are different; ie:
-      #         user1-3scale-mt-amp0-3-admin.apps.3295.openshift.opentlc.com 
+      #         user1-3scale-mt-amp0-3-admin.apps.3295.openshift.opentlc.com
       #         user1-3scale-mt-amp0-2-admin.apps.3295.openshift.opentlc.com
     - uri:
         url: "{{create_tenant_url}}"
@@ -80,12 +80,12 @@
         path: "{{tenant_output_dir}}/{{output_file}}"
         xpath: //account/id
         content: text
-      register: account_id 
+      register: account_id
     - xml:
         path: "{{tenant_output_dir}}/{{output_file}}"
         xpath: //user[state = "pending"]/id
         content: text
-      register: user_id 
+      register: user_id
     - debug:
         msg: "{{tenant_access_token.matches[0].value}}  {{account_id.matches[0].id}} {{user_id.matches[0].id}}"
         verbosity: 0
@@ -107,7 +107,7 @@
       command: "oc adm policy add-role-to-user view {{ocpAdminId}} -n {{API_MANAGER_NS}}"
 
     - name: "{{ocpAdminId}}  6) Populate {{tenant_output_dir}}/{{tenant_provisioning_results_file}}"
-      lineinfile: 
+      lineinfile:
         line: "{{ocpAdminId}}\t{{orgName}}-admin.{{ocp_apps_domain}}\t{{tenantAdminId}}\t{{tenantAdminPasswd}}\t{{tenant_access_token.matches[0].value}}"
         path: "{{tenant_output_dir}}/{{tenant_provisioning_results_file}}"
         create: yes
@@ -116,7 +116,7 @@
   when: create_or_delete_tenants == "create"
 
 #  ########################################################################################################## #
- 
+
 
 
 #  ############                 Create Corresponding API Gateways for each Tenant                   ######### #
@@ -131,10 +131,10 @@
 
     - set_fact:
         THREESCALE_PORTAL_ENDPOINT: "https://{{tenant_access_token.matches[0].value}}@{{orgName}}-admin.{{ocp_apps_domain}}"
-      when: tenant_reference_external_api_mgmt_routes|bool 
+      when: tenant_reference_external_api_mgmt_routes|bool
     - set_fact:
         THREESCALE_PORTAL_ENDPOINT: "http://{{tenant_access_token.matches[0].value}}@system-master.{{ API_MANAGER_NS }}:3000"
-      when: not tenant_reference_external_api_mgmt_routes|bool 
+      when: not tenant_reference_external_api_mgmt_routes|bool
 
     - name: "Create threescale-registry-auth image pull secret in {{ API_MANAGER_NS }}"
       shell: |
@@ -143,7 +143,7 @@
             --docker-username='{{ rht_service_token_user }}' \
             --docker-password={{ rht_service_token_password }} \
             -n  {{ gw_project_name }}
-
+      ignore_errors: true
 
     # https://access.redhat.com/solutions/3394561
     #   - stage gateway pulls proxy configs with every request to backend service
@@ -196,14 +196,14 @@
 
 
 #  ################################             Delete Tenant            ##################################### #
-#  URI of tenant delete API is:  
+#  URI of tenant delete API is:
 #          /master/api/providers/{id}.xml
 #  As of 3scale API Manager v2.2, there is not an API resource that allows for tenant lookup
-#  TO-DO: 
-#       implement mechanism to identify id of tenant.  
+#  TO-DO:
+#       implement mechanism to identify id of tenant.
 #       Probably best to do so as an xml file that is populated with creation of each tenant.
 #       In this section, the tenant xml snippet is located and deleted in this xml file
- 
+
 - block:
     - name: "{{ocpAdminId}}      **********   TENANT DELETION  **********"
       debug:


### PR DESCRIPTION
To addresses both local workstation and Bastion Server installation options, the Ansible role has to be installed in different directories. This pull request will provide both options in the readme.adoc file.

Named Tenant Creation command received an update, with new registry auth parameters passed.