### PR TITLE
update create secret command for 4.4

### DIFF
--- a/tasks/tenant_loop.yml
+++ b/tasks/tenant_loop.yml
@@ -146,8 +146,8 @@
 
     - name: "Create threescale-portal-endpoint secret in {{ API_MANAGER_NS }}"
       shell: |
-        oc secret new-basicauth apicast-configuration-url-secret \
-            --password={{ THREESCALE_PORTAL_ENDPOINT }} \
+        oc create secret generic apicast-configuration-url-secret \
+            --from-literal=password={{ THREESCALE_PORTAL_ENDPOINT }} \
             -n  {{ gw_project_name }}
     # https://access.redhat.com/solutions/3394561
     #   - stage gateway pulls proxy configs with every request to backend service


### PR DESCRIPTION
The current shell task doesn't work with OCP 4.4 since `oc secret new-basicauth` was deprecated and doesn't work. This is a quick fix to make it compatible with 4.4 until we can move to using Operators for this deployment.